### PR TITLE
Fix camera viewport

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use bevy::render::camera::ScalingMode;
 use bevy::{log::LogSettings, prelude::*};
 use bevy_ecs_ldtk::prelude::*;
 
@@ -25,9 +26,17 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     asset_server.watch_for_changes().unwrap();
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn_bundle(camera_setup());
     commands.spawn_bundle(LdtkWorldBundle {
         ldtk_handle: asset_server.load("boatmap.ldtk"),
         ..Default::default()
     });
+}
+
+fn camera_setup() -> Camera2dBundle {
+    let mut camera = Camera2dBundle::default();
+    camera.projection.scaling_mode = ScalingMode::WindowSize;
+    camera.projection.scale *= 1.5;
+
+    camera
 }

--- a/src/systems/camera_system.rs
+++ b/src/systems/camera_system.rs
@@ -1,9 +1,6 @@
+use crate::components::player::Player;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::{LdtkLevel, LevelSelection};
-
-use crate::components::player::Player;
-
-const ASPECT_RATIO: f32 = 16. / 9.;
 
 pub fn fit_inside_current_level(
     mut camera_query: Query<
@@ -27,39 +24,25 @@ pub fn fit_inside_current_level(
     }) = player_query.get_single()
     {
         let player_translation = *player_translation;
-        let (mut orthographic_projection, mut camera_transform) = camera_query.single_mut();
+        let (orthographic_projection, mut camera_transform) = camera_query.single_mut();
 
-        for (level_transform, level_handle) in level_query.iter() {
+        for (_, level_handle) in level_query.iter() {
             if let Some(ldtk_level) = ldtk_levels.get(level_handle) {
+                // The boundaries used to clamp the camera in the level
+                let (x_boundary_distance, y_boundary_distance) = (
+                    orthographic_projection.right * orthographic_projection.scale,
+                    orthographic_projection.top * orthographic_projection.scale,
+                );
                 let level = &ldtk_level.level;
                 if level_selection.is_match(&0, level) {
-                    let level_ratio = level.px_wid as f32 / ldtk_level.level.px_hei as f32;
-
-                    orthographic_projection.scaling_mode = bevy::render::camera::ScalingMode::None;
-                    orthographic_projection.bottom = 0.;
-                    orthographic_projection.left = 0.;
-                    if level_ratio > ASPECT_RATIO {
-                        // level is wider than the screen
-                        orthographic_projection.top = (level.px_hei as f32 / 9.).round() * 9.;
-                        orthographic_projection.right = orthographic_projection.top * ASPECT_RATIO;
-                        camera_transform.translation.x = (player_translation.x
-                            - level_transform.translation.x
-                            - orthographic_projection.right / 2.)
-                            .clamp(0., level.px_wid as f32 - orthographic_projection.right);
-                        camera_transform.translation.y = 0.;
-                    } else {
-                        // level is taller than the screen
-                        orthographic_projection.right = (level.px_wid as f32 / 16.).round() * 16.;
-                        orthographic_projection.top = orthographic_projection.right / ASPECT_RATIO;
-                        camera_transform.translation.y = (player_translation.y
-                            - level_transform.translation.y
-                            - orthographic_projection.top / 2.)
-                            .clamp(0., level.px_hei as f32 - orthographic_projection.top);
-                        camera_transform.translation.x = 0.;
-                    }
-
-                    camera_transform.translation.x += level_transform.translation.x;
-                    camera_transform.translation.y += level_transform.translation.y;
+                    camera_transform.translation.x = (player_translation.x).clamp(
+                        x_boundary_distance,
+                        level.px_wid as f32 - x_boundary_distance,
+                    );
+                    camera_transform.translation.y = (player_translation.y).clamp(
+                        y_boundary_distance,
+                        level.px_hei as f32 - y_boundary_distance,
+                    );
                 }
             }
         }

--- a/src/systems/player_system.rs
+++ b/src/systems/player_system.rs
@@ -1,17 +1,17 @@
 use crate::components::player::Player;
 use bevy::prelude::*;
 
-const MOVEMENT_SPEED: f32 = 500.;
+const MOVEMENT_SPEED: f32 = 200.;
 const MAX_DEGREES: f32 = 360.;
-const ROTATION_STEP: f32 = 0.5;
+const ROTATION_STEP: f32 = 0.2;
 const FORWARD_STEP: f32 = 1.;
 
 pub fn movement(
     time: Res<Time>,
     input: Res<Input<KeyCode>>,
-    mut query: Query<&mut Transform, With<Player>>,
+    mut player_query: Query<&mut Transform, With<Player>>,
 ) {
-    for mut transform in query.iter_mut() {
+    if let Ok(mut transform) = player_query.get_single_mut() {
         let mut rotation_input = 0.;
         let mut forward_input = 0.;
 


### PR DESCRIPTION
Add the autoscaling mode to the camera and calculate the boundaries to clamp it to the level boundaries.

This commit also lower the player speed and rotation.

Fixes #2 